### PR TITLE
Feature/dockstore 205 secondary file display

### DIFF
--- a/app/scripts/controllers/containerfileviewer.js
+++ b/app/scripts/controllers/containerfileviewer.js
@@ -154,11 +154,67 @@ angular.module('dockstore.ui')
           );
       };
 
+      $scope.getDescriptorFilePath = function(containerId, tagName, type) {
+        return ContainerService.getDescriptorFilePath(containerId, tagName, type)
+          .then(
+            function(descriptorFile) {
+              $scope.secondaryDescriptors = $scope.secondaryDescriptors.concat(descriptorFile);
+              $scope.secondaryDescriptors = $scope.secondaryDescriptors.filter(function(elem, index, self){return index == self.indexOf(elem)})
+              return $scope.secondaryDescriptors;
+            },
+            function(response) {
+              return $q.reject(response);
+            }
+          ).finally(
+            function() { $scope.fileLoaded = true; }
+          );
+      };
+
+      $scope.getSecondaryDescriptorFile = function(containerId, tagName, type, secondaryDescriptorPath) {
+        return ContainerService.getSecondaryDescriptorFile(containerId, tagName, type, encodeURIComponent(secondaryDescriptorPath))
+          .then(
+            function(descriptorFile) {
+              $scope.fileContents = descriptorFile;
+              return descriptorFile;
+            },
+            function(response) {
+              return $q.reject(response);
+            }
+          ).finally(
+            function() { $scope.fileLoaded = true; }
+          );
+      };
+
       $scope.setDocument = function() {
+        // prepare Container Version drop-down
         $scope.containerTags = $scope.getContainerTags();
         $scope.selTagName = $scope.containerTags[0];
+        // prepare Descriptor Type drop-down
         $scope.descriptors = descriptors;
         $scope.selDescriptorName = descriptors[0];
+        // prepare Descriptor Imports drop-down
+        $scope.secondaryDescriptors = $scope.containerObj.tags.filter(function(a) {return a.name === $scope.selTagName;})[0].sourceFiles.filter(function(a) {return a.type === 'DOCKSTORE_'+$scope.selDescriptorName.toUpperCase();}).map(function(a) {return a.path;});
+        $scope.selSecondaryDescriptorName = $scope.secondaryDescriptors[0];
+      };
+
+      $scope.refreshDocumentType = function() {
+        $scope.fileLoaded = false;
+        $scope.fileContents = null;
+        switch ($scope.type) {
+          case 'dockerfile':
+            $scope.expectedFilename = 'Dockerfile';
+            $scope.getDockerFile($scope.containerObj.id, $scope.selTagName);
+            break;
+          case 'descriptor':
+            $scope.expectedFilename = 'Descriptor';
+            // prepare Descriptor Imports drop-down
+            $scope.secondaryDescriptors = $scope.containerObj.tags.filter(function(a) {return a.name === $scope.selTagName;})[0].sourceFiles.filter(function(a) {return a.type === 'DOCKSTORE_'+$scope.selDescriptorName.toUpperCase();}).map(function(a) {return a.path;});
+            $scope.selSecondaryDescriptorName = $scope.secondaryDescriptors[0];
+            $scope.getSecondaryDescriptorFile($scope.containerObj.id, $scope.selTagName, $scope.selDescriptorName, $scope.selSecondaryDescriptorName);
+            break;
+          default:
+          // ...
+        }
       };
 
       $scope.refreshDocument = function() {
@@ -171,7 +227,7 @@ angular.module('dockstore.ui')
             break;
           case 'descriptor':
             $scope.expectedFilename = 'Descriptor';
-            $scope.getDescriptorFile($scope.containerObj.id, $scope.selTagName, $scope.selDescriptorName);
+            $scope.getSecondaryDescriptorFile($scope.containerObj.id, $scope.selTagName, $scope.selDescriptorName, $scope.selSecondaryDescriptorName);
             break;
           default:
             // ...

--- a/app/scripts/controllers/containerfileviewer.js
+++ b/app/scripts/controllers/containerfileviewer.js
@@ -143,7 +143,8 @@ angular.module('dockstore.ui')
         return ContainerService.getDescriptorFile(containerId, tagName, type)
           .then(
             function(descriptorFile) {
-              $scope.fileContents = descriptorFile;
+              // this seems to cause flickr when loading
+              // $scope.fileContents = descriptorFile;
               return descriptorFile;
             },
             function(response) {
@@ -185,6 +186,10 @@ angular.module('dockstore.ui')
           );
       };
 
+      function extracted(){
+        return $scope.containerObj.tags.filter(function(a) {return a.name === $scope.selTagName;})[0].sourceFiles.filter(function(a) {return a.type === 'DOCKSTORE_'+$scope.selDescriptorName.toUpperCase();}).map(function(a) {return a.path;}).sort();
+      }
+
       $scope.setDocument = function() {
         // prepare Container Version drop-down
         $scope.containerTags = $scope.getContainerTags();
@@ -193,7 +198,7 @@ angular.module('dockstore.ui')
         $scope.descriptors = descriptors;
         $scope.selDescriptorName = descriptors[0];
         // prepare Descriptor Imports drop-down
-        $scope.secondaryDescriptors = $scope.containerObj.tags.filter(function(a) {return a.name === $scope.selTagName;})[0].sourceFiles.filter(function(a) {return a.type === 'DOCKSTORE_'+$scope.selDescriptorName.toUpperCase();}).map(function(a) {return a.path;});
+        $scope.secondaryDescriptors = extracted();
         $scope.selSecondaryDescriptorName = $scope.secondaryDescriptors[0];
       };
 
@@ -208,7 +213,7 @@ angular.module('dockstore.ui')
           case 'descriptor':
             $scope.expectedFilename = 'Descriptor';
             // prepare Descriptor Imports drop-down
-            $scope.secondaryDescriptors = $scope.containerObj.tags.filter(function(a) {return a.name === $scope.selTagName;})[0].sourceFiles.filter(function(a) {return a.type === 'DOCKSTORE_'+$scope.selDescriptorName.toUpperCase();}).map(function(a) {return a.path;});
+            $scope.secondaryDescriptors = extracted();
             $scope.selSecondaryDescriptorName = $scope.secondaryDescriptors[0];
             $scope.getSecondaryDescriptorFile($scope.containerObj.id, $scope.selTagName, $scope.selDescriptorName, $scope.selSecondaryDescriptorName);
             break;

--- a/app/scripts/controllers/workflowfileviewer.js
+++ b/app/scripts/controllers/workflowfileviewer.js
@@ -15,7 +15,7 @@ angular.module('dockstore.ui')
     'NotificationService',
   	function ($scope, $q, WorkflowService, NtfnService) {
 
-      var descriptors = ["cwl", "wdl"];
+      $scope.descriptor = $scope.workflowObj.descriptorType;
 
       $scope.fileLoaded = false;
       $scope.fileContents = null;
@@ -27,19 +27,17 @@ angular.module('dockstore.ui')
         var accumulator = [];
         var index = 0;
         for (var i=0; i<$scope.workflowVersions.length; i++) {
-          for (var j=0; j<descriptors.length; j++) {
-            accumulator[index] = {ver: $scope.workflowVersions[i], desc: descriptors[j]};
+            accumulator[index] = {ver: $scope.workflowVersions[i]};
             index++;
-          };
-        };
+        }
 
         var checkSuccess = function(acc) {
           var makePromises = function(acc, start) {
             var vd = acc[start];
             function filePromise(vd){
-              return $scope.getDescriptorFile($scope.workflowObj.id, vd.ver, vd.desc).then(
+              return $scope.getDescriptorFile($scope.workflowObj.id, vd.ver, $scope.descriptor).then(
                 function(s){
-                  $scope.successContent.push({version:vd.ver,descriptor:vd.desc});
+                  $scope.successContent.push({version:vd.ver});
                   if(start+1 === acc.length) {
                     return {success: true, index:start};
                   } else{
@@ -53,19 +51,18 @@ angular.module('dockstore.ui')
                   } else {
                     start++;
                     return filePromise(acc[start]);
-                  };
+                  }
                 });
             }
             return filePromise(vd);
           };
           return makePromises(acc,0);
-        }
+        };
 
         var successResult = checkSuccess(accumulator);
         successResult.then(
           function(result){
             $scope.selVersionName = $scope.successContent[0].version;
-            $scope.selDescriptorName = $scope.successContent[0].descriptor;
           },
           function(e){console.log("error",e)}
         );
@@ -119,7 +116,8 @@ angular.module('dockstore.ui')
         return WorkflowService.getDescriptorFile(workflowId, versionName, type)
           .then(
             function(descriptorFile) {
-              $scope.fileContents = descriptorFile;
+              // this causes flicker when loading
+              //$scope.fileContents = descriptorFile;
               return descriptorFile;
             },
             function(response) {
@@ -130,20 +128,79 @@ angular.module('dockstore.ui')
           );
       };
 
+      $scope.getDescriptorFilePath = function(containerId, tagName, type) {
+        return WorkflowService.getDescriptorFilePath(containerId, tagName, type)
+          .then(
+            function(descriptorFile) {
+              $scope.secondaryDescriptors = $scope.secondaryDescriptors.concat(descriptorFile);
+              $scope.secondaryDescriptors = $scope.secondaryDescriptors.filter(function(elem, index, self){return index == self.indexOf(elem)})
+              return $scope.secondaryDescriptors;
+            },
+            function(response) {
+              return $q.reject(response);
+            }
+          ).finally(
+            function() { $scope.fileLoaded = true; }
+          );
+      };
+
+      $scope.getSecondaryDescriptorFile = function(containerId, tagName, type, secondaryDescriptorPath) {
+        return WorkflowService.getSecondaryDescriptorFile(containerId, tagName, type, encodeURIComponent(secondaryDescriptorPath))
+          .then(
+            function (descriptorFile) {
+              $scope.fileContents = descriptorFile;
+              return descriptorFile;
+            },
+            function (response) {
+              return $q.reject(response);
+            }
+          ).finally(
+            function () {
+              $scope.fileLoaded = true;
+            }
+          );
+      };
+
+      function extracted(){
+        try {
+          return $scope.workflowObj.workflowVersions.filter(function (a) {
+            return a.name === $scope.selVersionName;
+          })[0].sourceFiles.filter(function (a) {
+            return a.type === 'DOCKSTORE_' + $scope.descriptor.toUpperCase();
+          }).map(function (a) {
+            return a.path;
+          }).sort();
+        } catch(err){
+          return [];
+        }
+      }
+
       $scope.setDocument = function() {
-        $scope.workflowVersions = $scope.getWorkflowVersions();
+        $scope.descriptor = $scope.workflowObj.descriptorType;
+        // prepare Workflow Version drop-down
+        $scope.workflowVersions = $scope.workflowObj.workflowVersions.map(function(a) {return a.name;}).sort();
         $scope.selVersionName = $scope.workflowVersions[0];
-        $scope.descriptors = descriptors;
-        $scope.selDescriptorName = descriptors[0];
+        // prepare Descriptor Imports drop-down
+        $scope.secondaryDescriptors = extracted();
+        $scope.selSecondaryDescriptorName = $scope.secondaryDescriptors[0];
+      };
+
+      $scope.refreshDocumentType = function() {
+        $scope.fileLoaded = false;
+        $scope.fileContents = null;
+        $scope.expectedFilename = 'Descriptor';
+        $scope.secondaryDescriptors = extracted();
+        $scope.selSecondaryDescriptorName = $scope.secondaryDescriptors[0];
+        $scope.getSecondaryDescriptorFile($scope.workflowObj.id, $scope.selVersionName, $scope.descriptor, $scope.selSecondaryDescriptorName);
       };
 
       $scope.refreshDocument = function() {
         $scope.fileLoaded = false;
         $scope.fileContents = null;
         $scope.expectedFilename = 'Descriptor';
-        $scope.getDescriptorFile($scope.workflowObj.id, $scope.selVersionName, $scope.selDescriptorName);
-      };    
-      
+        $scope.getSecondaryDescriptorFile($scope.workflowObj.id, $scope.selVersionName, $scope.descriptor, $scope.selSecondaryDescriptorName);
+      };
+
       $scope.setDocument();
 
   }]);

--- a/app/scripts/controllers/workflowfileviewer.js
+++ b/app/scripts/controllers/workflowfileviewer.js
@@ -23,6 +23,9 @@ angular.module('dockstore.ui')
 
       $scope.checkDescriptor = function() {
         $scope.workflowVersions = $scope.getWorkflowVersions();
+        if ($scope.workflowVersions.length === 0){
+          return;
+        }
         $scope.successContent = [];
         var accumulator = [];
         var index = 0;
@@ -145,6 +148,9 @@ angular.module('dockstore.ui')
       };
 
       $scope.getSecondaryDescriptorFile = function(containerId, tagName, type, secondaryDescriptorPath) {
+        if(typeof $scope.selVersionName === 'undefined' || typeof $scope.selSecondaryDescriptorName === 'undefined'){
+          return;
+        }
         return WorkflowService.getSecondaryDescriptorFile(containerId, tagName, type, encodeURIComponent(secondaryDescriptorPath))
           .then(
             function (descriptorFile) {

--- a/app/scripts/directives/containerfileviewer.js
+++ b/app/scripts/directives/containerfileviewer.js
@@ -25,7 +25,12 @@ angular.module('dockstore.ui')
           }
         });
         scope.$watchGroup(
-          ['selTagName', 'containerObj.id', 'selDescriptorName'],
+          ['selDescriptorName'],
+          function(newValues, oldValues) {
+            scope.refreshDocumentType();
+          });
+        scope.$watchGroup(
+          ['selTagName', 'containerObj.id', 'selSecondaryDescriptorName'],
           function(newValues, oldValues) {
             scope.refreshDocument();
         });

--- a/app/scripts/directives/containerfileviewer.js
+++ b/app/scripts/directives/containerfileviewer.js
@@ -24,6 +24,13 @@ angular.module('dockstore.ui')
             scope.checkDescriptor();
           }
         });
+        scope.$on('refreshFiles', function(event) {
+          scope.setDocument();
+          scope.refreshDocument();
+        });
+        scope.$on('checkDescPageType', function(event) {
+          scope.checkDescriptor();
+        });
         scope.$watchGroup(
           ['selDescriptorName'],
           function(newValues, oldValues) {
@@ -33,14 +40,7 @@ angular.module('dockstore.ui')
           ['selTagName', 'containerObj.id', 'selSecondaryDescriptorName'],
           function(newValues, oldValues) {
             scope.refreshDocument();
-        });
-        scope.$on('refreshFiles', function(event) {
-          scope.setDocument();
-          scope.refreshDocument();
-        });
-        scope.$on('checkDescPageType', function(event) {
-          scope.checkDescriptor();
-        });
+          });
       }
     };
   });

--- a/app/scripts/directives/workflowfileviewer.js
+++ b/app/scripts/directives/workflowfileviewer.js
@@ -24,11 +24,6 @@ angular.module('dockstore.ui')
             scope.checkDescriptor();
           }
         });
-        scope.$watchGroup(
-          ['selVersionName', 'workflowObj.id', 'selDescriptorName'],
-          function(newValues, oldValues) {
-            scope.refreshDocument();
-        });
         scope.$on('refreshFiles', function(event) {
           scope.setDocument();
           scope.refreshDocument();
@@ -36,6 +31,16 @@ angular.module('dockstore.ui')
         scope.$on('checkDescPageType', function(event) {
           scope.checkDescriptor();
         });
+        scope.$watchGroup(
+          ['selVersionName','descriptor'],
+          function(newValues, oldValues) {
+            scope.refreshDocumentType();
+          });
+        scope.$watchGroup(
+          ['workflowObj.id', 'selSecondaryDescriptorName'],
+          function(newValues, oldValues) {
+            scope.refreshDocument();
+          });
       }
     };
   });

--- a/app/scripts/services/containerservice.js
+++ b/app/scripts/services/containerservice.js
@@ -333,4 +333,37 @@ angular.module('dockstore.ui')
       });
     };
 
+        this.getDescriptorFilePath = function(containerId, tagName, type) {
+          return $q(function(resolve, reject) {
+            $http({
+              method: 'GET',
+              url: WebService.API_URI + '/containers/' + containerId + '/' + type,
+              params: {
+                tag: tagName
+              }
+            }).then(function(response) {
+              resolve(response.data.path);
+            }, function(response) {
+              reject(response);
+            });
+          });
+        };
+
+        this.getSecondaryDescriptorFile = function (containerId, tagName, type, secondaryDescriptorPath) {
+          return $q(function (resolve, reject) {
+            $http({
+              method: 'GET',
+              url: WebService.API_URI + '/containers/' + containerId + '/' + type + '/' + secondaryDescriptorPath,
+              params: {
+                tag: tagName
+              }
+            }).then(function (response) {
+              resolve(response.data.content);
+            }, function (response) {
+              reject(response);
+            });
+          });
+        };
+
+
   }]);

--- a/app/scripts/services/workflowservice.js
+++ b/app/scripts/services/workflowservice.js
@@ -128,8 +128,8 @@ angular.module('dockstore.ui')
         });
       });
     };
-    
-    // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274 
+
+    // this is actually a partial update, see https://github.com/ga4gh/dockstore/issues/274
     this.setDefaultWorkflowPath = function(workflowId, workflowpath, workflowname, descType,path, giturl) {
       return $q(function(resolve, reject) {
         $http({
@@ -205,4 +205,38 @@ angular.module('dockstore.ui')
         });
       });
     };
+
+
+        this.getDescriptorFilePath = function(containerId, tagName, type) {
+          return $q(function(resolve, reject) {
+            $http({
+              method: 'GET',
+              url: WebService.API_URI + '/workflows/' + containerId + '/' + type,
+              params: {
+                tag: tagName
+              }
+            }).then(function(response) {
+              resolve(response.data.path);
+            }, function(response) {
+              reject(response);
+            });
+          });
+        };
+
+        this.getSecondaryDescriptorFile = function (containerId, tagName, type, secondaryDescriptorPath) {
+          return $q(function (resolve, reject) {
+            $http({
+              method: 'GET',
+              url: WebService.API_URI + '/workflows/' + containerId + '/' + type + '/' + secondaryDescriptorPath,
+              params: {
+                tag: tagName
+              }
+            }).then(function (response) {
+              resolve(response.data.content);
+            }, function (response) {
+              reject(response);
+            });
+          });
+        };
+
   }]);

--- a/app/styles/ds-style-fix.scss
+++ b/app/styles/ds-style-fix.scss
@@ -338,6 +338,11 @@ select.ds-descriptor {
   width: 120px;
 }
 
+select.ds-wide-descriptor {
+  width: 220px;
+}
+
+
 div.ds-version-selector {
   display: table-cell;
 }

--- a/app/templates/containerfileviewer.html
+++ b/app/templates/containerfileviewer.html
@@ -19,6 +19,17 @@
       </option>
     </select>
   </div>
+
+  <div class="ds-descriptor-selector" ng-hide="isDockerfile()">
+    <strong>File</strong>:
+    <select class="ds-wide-descriptor" ng-model="selSecondaryDescriptorName">
+      <option
+        ng-repeat="secondaryDescriptorPath in secondaryDescriptors"
+        value="{{secondaryDescriptorPath}}">
+        {{secondaryDescriptorPath}}
+      </option>
+    </select>
+  </div>
 </div>
 
 <div class="alert alert-warning" role="alert"

--- a/app/templates/workflowfileviewer.html
+++ b/app/templates/workflowfileviewer.html
@@ -9,16 +9,18 @@
       </option>
     </select>
   </div>
+
   <div class="ds-descriptor-selector">
-    <strong>Descriptor Type</strong>:
-    <select class="ds-descriptor" ng-model="selDescriptorName">
+    <strong>File</strong>:
+    <select class="ds-wide-descriptor" ng-model="selSecondaryDescriptorName">
       <option
-        ng-repeat="descriptor in descriptors | filter: filterDescriptor"
-        value="{{descriptor}}">
-        {{descriptor}}
+        ng-repeat="secondaryDescriptorPath in secondaryDescriptors"
+        value="{{secondaryDescriptorPath}}">
+        {{secondaryDescriptorPath}}
       </option>
     </select>
   </div>
+</div>
 </div>
 
 <div class="alert alert-warning" role="alert"


### PR DESCRIPTION
Implementation for https://github.com/ga4gh/dockstore/issues/205
- secondary file display for CWL, WDL in both tools and workflows
- removed cwl/wdl drop-down in workflows since it doesn't really make any sense any more
  Will probably need a pass to see if I'm doing anything parricularly weird
