### PR TITLE
Allow yml and yaml as synonyms for CWL

### DIFF
--- a/app/scripts/controllers/containerdetails.js
+++ b/app/scripts/controllers/containerdetails.js
@@ -133,7 +133,7 @@ angular.module('dockstore.ui')
       $scope.checkContentValid = function(){
         //will print this when the 'Publish' button is clicked
         var message = 'The file is missing some required fields. Please make sure the file has all the required fields. ';
-        var missingMessage = 'The missing field(s):'
+        var missingMessage = 'The missing field(s):';
         if($scope.validContent){
           if($scope.missingContent.length !== 0){
             $scope.missingWarning = true;

--- a/app/scripts/directives/containerfileviewer.js
+++ b/app/scripts/directives/containerfileviewer.js
@@ -32,12 +32,12 @@ angular.module('dockstore.ui')
           scope.checkDescriptor();
         });
         scope.$watchGroup(
-          ['selDescriptorName'],
+          ['selTagName', 'selDescriptorName'],
           function(newValues, oldValues) {
             scope.refreshDocumentType();
           });
         scope.$watchGroup(
-          ['selTagName', 'containerObj.id', 'selSecondaryDescriptorName'],
+          ['containerObj.id', 'selSecondaryDescriptorName'],
           function(newValues, oldValues) {
             scope.refreshDocument();
           });

--- a/app/templates/registercontainer.html
+++ b/app/templates/registercontainer.html
@@ -116,7 +116,7 @@
                   ng-model="containerObj.default_cwl_path"
                   ng-minlength="3"
                   ng-maxlength="256"
-                  ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.cwl$/i"
+                  ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|yaml|yml)$/i"
                   required
                   data-toggle="tooltip"
                   title="Default relative path to the CWL Descriptor in the Git repository."

--- a/app/templates/registerworkflow.html
+++ b/app/templates/registerworkflow.html
@@ -111,7 +111,7 @@
                   value="{{workflowObj.default_workflow_path}}"
                   ng-minlength="3"
                   ng-maxlength="256"
-                  ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|wdl)$/i"
+                  ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|wdl|yaml|yml)$/i"
                   required
                   data-toggle="tooltip"
                   title="Default relative path to the Descriptor in the Git repository."

--- a/app/templates/tageditor.html
+++ b/app/templates/tageditor.html
@@ -149,7 +149,7 @@
                   ng-model="tagObj.cwl_path"
                   ng-minlength="3"
                   ng-maxlength="128"
-                  ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.cwl$/i"
+                  ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|yaml|yml)/i"
                   required
                   data-toggle="tooltip"
                   title="Relative path to the CWL Descriptor in the Git repository."

--- a/app/templates/validation/containers/descriptorpath.html
+++ b/app/templates/validation/containers/descriptorpath.html
@@ -8,5 +8,5 @@
   Dockerfile Path is too long. (Max 128 characters.)
 </p>
 <p ng-message="pattern">
-  Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.cwl' or '*.wdl'.
+  Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.cwl', '*.yml', '*.yaml', or'*.wdl'.
 </p>

--- a/app/templates/validation/tags/descriptorpath.html
+++ b/app/templates/validation/tags/descriptorpath.html
@@ -8,5 +8,5 @@
   Dockerfile Path is too long. (Max 128 characters.)
 </p>
 <p ng-message="pattern">
-  Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.cwl' or '*.wdl'.
+  Invalid Descriptor Path format. Descriptor Path must begin with '/' and end with '*.cwl', '*.yml', '*.yaml', or'*.wdl'.
 </p>

--- a/app/templates/validation/workflows/descriptorpath.html
+++ b/app/templates/validation/workflows/descriptorpath.html
@@ -8,5 +8,5 @@
   Workflow Path is too long. (Max 128 characters.)
 </p>
 <p ng-message="pattern">
-  Invalid Workflow Path format. Workflow Path must begin with '/' and end with '*.cwl' or '*.wdl'.
+  Invalid Workflow Path format. Workflow Path must begin with '/' and end with end with '*.cwl', '*.yml', '*.yaml', or'*.wdl'.
 </p>

--- a/app/templates/versiontageditor.html
+++ b/app/templates/versiontageditor.html
@@ -95,7 +95,7 @@
                 ng-model="versionTagObj.workflow_path"
                 ng-minlength="3"
                 ng-maxlength="128"
-                ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|wdl)$/i"
+                ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|wdl|yml|yaml)$/i"
                 required
                 data-toggle="tooltip"
                 title="Relative path to the Descriptor in the Git repository."

--- a/app/templates/workflowdetails.html
+++ b/app/templates/workflowdetails.html
@@ -156,7 +156,7 @@
               <strong>Workflow Path</strong>:
               {{workflowObj.workflow_path}}
             </div>
-            
+
           <!-- for when it's edit mode and Edit button not clicked-->
             <div ng-show="editMode && showEditWorkflowPath">
               <strong>Workflow Path</strong>:
@@ -187,7 +187,7 @@
                       class="input-default form-control"
                       name="contDescPath"
                       ng-model="workflowObj.workflow_path"
-                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|wdl)$/i"
+                      ng-pattern="/^\/([^\\\/\?\:\*\|\<\>]+\/)*[^\\\/\?\:\*\|\<\>]+\.(cwl|wdl|yaml|yml)$/i"
                       ng-minlength="3"
                       ng-maxlength="256"
                       placeholder="e.g. /Dockstore.cwl" />


### PR DESCRIPTION
- affects validation and validation messages
- also fix issue where changing tag name would not bring up new listing of secondary file paths 

Also see https://github.com/ga4gh/dockstore/pull/295
