### PR TITLE
Feature/chrome experiment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: true
+dist: trusty
 language: node_js
 node_js:
   - 'stable'
@@ -6,9 +7,16 @@ node_js:
 before_install:
   - 'npm config get registry'
   - 'npm config set registry http://registry.npmjs.org/'
+  - 'export CHROME_BIN=/usr/bin/google-chrome'
+  - 'export DISPLAY=:99.0'
+  - 'sh -e /etc/init.d/xvfb start'
+  - 'sudo apt-get update'
+  - 'sudo apt-get install -y libappindicator1 fonts-liberation'
+  - 'wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb'
+  - 'sudo dpkg -i google-chrome*.deb'
 install:
   - 'npm install --global grunt-cli bower yo generator-karma generator-angular'
-  - 'npm install karma jasmine-core phantomjs'
+  - 'npm install karma jasmine-core'
   - 'sudo apt-get install -y ruby ruby-dev make'
   - 'gem install compass'
   - 'npm update'

--- a/e2e.conf.js
+++ b/e2e.conf.js
@@ -17,8 +17,7 @@ exports.config = {
 
 	// Capabilities to be passed to the webdriver instance.
 	capabilities: {
-		'browserName': 'phantomjs',
-		'phantomjs.binary.path' : 'node_modules/phantomjs-prebuilt/bin/phantomjs'
+		'browserName': 'chrome'
 	},
 
 	baseUrl: 'http://localhost:9001/', //must be 9001 because grunt-test is in port 9001

--- a/e2e.conf.js
+++ b/e2e.conf.js
@@ -2,18 +2,7 @@ exports.config = {
 
 	allScriptsTimeout: 99999,
 
-	// The address of a running selenium server.
-	//seleniumAddress: 'http://localhost:4444/wd/hub',
-
-	// The location of the selenium standalone server .jar file, relative
-	// to the location of this config. If no other method of starting selenium
-	// is found, this will default to
-	// node_modules/protractor/selenium/selenium-server...
-	seleniumServerJar: 'node_modules/grunt-protractor-runner/node_modules/protractor/selenium/selenium-server-standalone-2.52.0.jar',
-
-	// The port to start the selenium server on, or null if the server should
-	// find its own unused port.
-	seleniumPort: 4444,
+	directConnect: true,
 
 	// Capabilities to be passed to the webdriver instance.
 	capabilities: {

--- a/package.json
+++ b/package.json
@@ -35,11 +35,9 @@
     "jit-grunt": "^0.10.0",
     "jshint-stylish": "^2.2.0",
     "karma": "^1.1.1",
-    "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^1.1.1",
+    "karma-chrome-launcher": "^1.0.1",
     "karma-jasmine": "^1.0.2",
-    "karma-phantomjs-launcher": "^1.0.1",
-    "phantomjs-prebuilt": "^2.1.10",
     "protractor": "^4.0.2",
     "serve-static": "^1.11.1",
     "time-grunt": "^1.0.0"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -115,6 +115,6 @@ module.exports = function(config) {
   });
 
   if(process.env.TRAVIS) {  
-    configuration.browsers = ['Chrome_travis_ci'];
+    config.browsers = ['Chrome_travis_ci'];
   }
 };

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -56,6 +56,13 @@ module.exports = function(config) {
     exclude: [
     ],
 
+    customLaunchers: {  
+      Chrome_travis_ci: {
+         base: 'Chrome',
+	 flags: ['--no-sandbox']
+      }
+    },
+
     // web server port
     port: 8080,
 
@@ -68,12 +75,12 @@ module.exports = function(config) {
     // - PhantomJS
     // - IE (only Windows)
     browsers: [
-      "PhantomJS"
+      "Chrome"
     ],
 
     // Which plugins to enable
     plugins: [
-      "karma-phantomjs-launcher",
+      "karma-chrome-launcher",
       "karma-coverage",
       "karma-jasmine"
     ],
@@ -106,4 +113,8 @@ module.exports = function(config) {
       dir: 'build/coverage/'
     }
   });
+
+  if(process.env.TRAVIS) {  
+    configuration.browsers = ['Chrome_travis_ci'];
+  }
 };


### PR DESCRIPTION
Make tests a bit more representative by switching from PhantomJS (recommended against by Protractor) to Chrome. Also should be marginally faster and lighter.

See 
http://blog.500tech.com/setting-up-travis-ci-to-run-tests-on-latest-google-chrome-version/
http://www.protractortest.org/#/browser-setup#setting-up-phantomjs
- [x] Check that you pass the basic compilation and unit tests by running `grunt` 
