### PR TITLE
Make formatting of API versions consistent for #363

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -581,9 +581,9 @@ module.exports = function (grunt) {
   grunt.registerTask('build', function(target){
     
     grunt.log.write("revision: "+gitRev);
-    grunt.file.write('./app/gitVersion.htm',"<br>DockstoreUI&nbsp-&nbsp"+gitTag+
-      "-&nbsp<a href=\"https://github.com/ga4gh/dockstore-ui/commit/"+gitRev+"\" target=\"_blank\" style=\"color:white\">"+
-      gitRev+"</a>");
+    grunt.file.write('./app/gitVersion.htm',"<br>DockstoreUI&nbsp-&nbsp"+
+      "<a href=\"https://github.com/ga4gh/dockstore-ui/commit/"+gitRev+"\" target=\"_blank\" style=\"color:white\">"+
+      gitTag+"</a>");
 
     grunt.task.run([
       'clean:dist',

--- a/app/index.html
+++ b/app/index.html
@@ -43,7 +43,7 @@
           <img src="images/github.png"><a href="https://github.com/ga4gh/dockstore">Github Repository</a>
           <img src="images/twitter.png"><a href="https://twitter.com/DockstoreOrg">Follow Us</a>
         </span>
-        <span style="font-size: 12px;">
+        <span style="font-size: 12px; line-height: 1em">
 	        <!-- git version -->
           <div footnote></div>
         </span>

--- a/app/templates/footnote.html
+++ b/app/templates/footnote.html
@@ -1,2 +1,2 @@
-DockstoreApi - {{ apiVersion }}
+DockstoreApi - <a href="https://github.com/ga4gh/dockstore/releases/tag/{{ apiVersion }}" target="_blank" style="color:white">{{ apiVersion }}</a>
 


### PR DESCRIPTION
Match API links and formatting
https://github.com/ga4gh/dockstore/issues/363
- [x] Check that you pass the basic compilation and unit tests by running `grunt` 
