### PR TITLE
Feature/tool title match ga4gh

### DIFF
--- a/app/scripts/controllers/containereditor.js
+++ b/app/scripts/controllers/containereditor.js
@@ -245,7 +245,7 @@ angular.module('dockstore.ui')
           mode: 'MANUAL_IMAGE_PATH',
           name: '',
           toolname: '',
-          namespace: namespace ? namespace : '',
+          namespace: namespace ? namespace.split('/')[1] : '',
           registry: '',
           gitUrl: '',
           default_dockerfile_path: '/Dockerfile',

--- a/app/scripts/controllers/containereditor.js
+++ b/app/scripts/controllers/containereditor.js
@@ -84,10 +84,11 @@ angular.module('dockstore.ui')
           return -1;
         };
         for (var i = 0; i < containers.length; i++) {
-          var pos = getNSIndex(containers[i].namespace);
+          var prefix = containers[i].tool_path.split('/',2).join('/');
+          var pos = getNSIndex(prefix);
           if (pos < 0) {
             nsContainers.push({
-              namespace: containers[i].namespace,
+              namespace: prefix,
               containers: []
             });
             pos = nsContainers.length - 1;

--- a/app/templates/containerdetails.html
+++ b/app/templates/containerdetails.html
@@ -48,9 +48,7 @@
     <h3>
       <!--<span class="glyphicon glyphicon-lock" ng-if="!containerObj.is_public"></span>-->
       {{
-        (containerObj.namespace !== '_' ? containerObj.namespace + '/' : '') +
-        containerObj.name +
-        (containerObj.toolname ? ' (' + containerObj.toolname + ')' : '')
+        (containerObj.tool_path)
       }}
     </h3>
     <div ng-if="containerObj" id="label-holder">
@@ -149,14 +147,6 @@
       <uib-tab active="activeTabs[0]">
         <uib-tab-heading>Info</uib-tab-heading>
         <ul class="list-unstyled container-info">
-          <li>
-            <strong>Name</strong>:
-            {{containerObj.name + (containerObj.toolname ? ' (' + containerObj.toolname + ')' : '')}}
-          </li>
-          <li>
-            <strong>Path</strong>:
-            {{containerObj.path}}
-          </li>
           <li>
             <strong>Author</strong>:
             {{ containerObj.author ? containerObj.author : 'n/a' }}
@@ -367,6 +357,31 @@
               </span>
             </div>
           </li>
+                 <li ng-show="showLaunchWith()">
+            <strong>Launch With:</strong>
+            <div class="pull-right" style="margin-left:5px">
+                <select id="descType"
+                ng-model="desc"
+                ng-options="descType for descType in descAvailable"
+                ng-change="descLaunchWith(desc)">
+                </select>
+              </div>
+            <div class="pull-right" style="margin-left:5px">
+              <select id="tagVersion"
+                ng-model="toolTag"
+                ng-options="tag.id as tag.name for tag in validTags"
+                ng-change="tagLaunchWith(toolTag)">
+                </select>
+            </div>
+
+            <div class="well well-sm">
+              <div>
+                <pre>{{launchWith}}</pre>
+              </div>
+            </div>
+          </li>
+
+
         </ul>
         <div ng-if="!editMode">
           <hr />

--- a/app/templates/containersgrid.html
+++ b/app/templates/containersgrid.html
@@ -36,7 +36,7 @@
             <!-- need a to write a 'smart search' filter -->
             <tr ng-repeat="container in ((filteredContainers = (containers | PreviewFilter:contLimit | filter: searchQueryContainer)) | orderBy:sortColumn:sortReverse | PaginationFilter:getListRange())">
               <td>
-                <a href="/containers/{{container.tool_path}}">{{container.tool_path}}</a>
+                <a href="/containers/{{container.tool_path}}">{{container.name + (container.toolname ? '/' + container.toolname : '')}}</a>
               </td>
               <td>
                 {{ container.author ? container.author : 'n/a' }}

--- a/app/templates/containersgrid.html
+++ b/app/templates/containersgrid.html
@@ -36,7 +36,7 @@
             <!-- need a to write a 'smart search' filter -->
             <tr ng-repeat="container in ((filteredContainers = (containers | PreviewFilter:contLimit | filter: searchQueryContainer)) | orderBy:sortColumn:sortReverse | PaginationFilter:getListRange())">
               <td>
-                <a href="/containers/{{container.path + (container.toolname ? '/' + container.toolname : '')}}">{{container.name + (container.toolname ? ' (' + container.toolname + ')' : '')}}</a>
+                <a href="/containers/{{container.tool_path}}">{{container.tool_path}}</a>
               </td>
               <td>
                 {{ container.author ? container.author : 'n/a' }}

--- a/app/views/containereditor.html
+++ b/app/views/containereditor.html
@@ -76,10 +76,10 @@
                 ng-class="{selected: selContainerObj.id === containerObj.id}"
                 ng-repeat="containerObj in nsObj.containers">
               <div class="container-name-oflw pull-left"
-                  title="{{containerObj.name + (containerObj.toolname ? ' (' + containerObj.toolname + ')' : '')}}"
+                  title="{{containerObj.name + (containerObj.toolname ? '/' + containerObj.toolname : '')}}"
                   data-toggle="tooltip">
                 <a href ng-click="selectContainer(containerObj.id)">
-                  {{containerObj.name + (containerObj.toolname ? ' (' + containerObj.toolname + ')' : '')}}
+                  {{containerObj.name + (containerObj.toolname ? '/' + containerObj.toolname : '')}}
                 </a>
               </div>
               <div class="pull-right">


### PR DESCRIPTION
Change the tool title to match the GA4GH id for simplicity
Also better group tools in "My Tools" based on registry + organization rather than just organization

https://github.com/ga4gh/dockstore/issues/377
- [x] Check that you pass the basic compilation and unit tests by running `grunt` 
