### PR TITLE
Looks like minor version update beyond this breaks uglify

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "grunt-contrib-htmlmin": "^2.0.0",
     "grunt-contrib-imagemin": "^1.0.1",
     "grunt-contrib-jshint": "^1.0.0",
-    "grunt-contrib-uglify": "^2.0.0",
+    "grunt-contrib-uglify": "2.1.0",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-filerev": "^2.1.2",
     "grunt-google-cdn": "^0.4.3",


### PR DESCRIPTION
The symptom at build time is the following. 
At runtime the site simply fails to load except for the header. 
```
Running "uglify:generated" (uglify) task
WARN: Output exceeds 32000 characters
File dist/scripts/vendor.js created: 4.45 MB → 1.54 MB
File dist/scripts/scripts.js created: 546.78 kB → 315.5 kB
>> 2 files created.
```

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Check that you pass the basic compilation and unit tests by running `grunt` 
